### PR TITLE
Added 'configger' utilities: file < wandb < cmd line

### DIFF
--- a/configger/__init__.py
+++ b/configger/__init__.py
@@ -1,0 +1,1 @@
+from . import configger

--- a/configger/configger.py
+++ b/configger/configger.py
@@ -1,3 +1,12 @@
+# -*- coding: utf-8 -*-
+__author__ = 'S.H. Hawley'
+
+"""
+Routines for easily keeping track of & archiving run configurations.
+Supports config (.ini) files, pulling previous configs from WandB, 
+and overrides with command-line options.
+"""
+
 from pathlib import Path
 from ast import literal_eval 
 import argparse

--- a/configger/configger.py
+++ b/configger/configger.py
@@ -78,8 +78,8 @@ def setup_args(defaults, defaults_text=''):
     
 
 def pull_wandb_config(wandb_config, defaults):
-    """overwrites parts of args using wandb config info 
-    wandb_config is the url of one of your runs"""
+    """overwrites parts of defaults using wandb config info 
+       wandb_config is the url of one of your runs"""
     api = wandb.Api()  # might get prompted for api key login the first time
     splits = wandb_config.split('/')
     entity, project, run_id = splits[3], splits[4], splits[-1].split('?')[0]

--- a/configger/configger.py
+++ b/configger/configger.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from ast import literal_eval 
+import argparse
+import configparser
+import wandb
+
+def arg_eval(value):
+    "this just packages some type checking for parsing args"
+    try: 
+        val = literal_eval(str(value))
+    except (SyntaxError, ValueError, AssertionError):
+        val = value
+    return val
+
+def read_defaults(defaults_file='defaults.ini'):
+    "read the defaults file, setup defaults dict"
+    configp = configparser.ConfigParser()
+    configp.read(defaults_file)
+    defaults = dict(configp.items('DEFAULTS'))
+    with open(defaults_file) as f:
+        defaults_text = f.readlines()
+    return defaults, defaults_text
+
+
+def setup_args(defaults, defaults_text=''):
+    """combine defaults from .ini file and add parseargs arguments, 
+        with help pull from .ini"""
+    p = argparse.ArgumentParser()  
+    p.add_argument('--wandb-config', required=False,  
+                   help='wandb url to pull config from')
+    p.add_argument('--training-dir', type=Path, required=False,
+                   help='training data directory')
+    p.add_argument('--name', type=str, required=False,
+                   help='name of the run')
+
+    # add other command-line args using defaults
+    for key, value in defaults.items():
+        if (key in ['training_dir', 'name', 'wandb_config']): break
+        help = ""
+        for i in range(len(defaults_text)):  # get the help string from defaults_text
+            if key in defaults_text[i]:
+                help = defaults_text[i-1].replace('# ','')
+        argname = '--'+key.replace('_','-')
+        val = arg_eval(value)
+        p.add_argument(argname, default=val, type=type(val), help=help)
+
+    args = p.parse_args() 
+
+    if (args.training_dir is None) and ('training_dir' in defaults):
+        args.training_dir = Path(defaults['training_dir'])
+    if (args.name is None) and ('name' in defaults):
+        args.name = Path(defaults['name'])
+
+    return args
+    
+
+def pull_wandb_config(wandb_config, defaults):
+    """overwrites parts of args using wandb config info 
+    wandb_config is the url of one of your runs"""
+    api = wandb.Api()  # might get prompted for api key login the first time
+    splits = wandb_config.split('/')
+    entity, project, run_id = splits[3], splits[4], splits[-1].split('?')[0]
+    run = api.run(f"{entity}/{project}/{run_id}")
+    for key, value in run.config.items():
+        defaults[key] = arg_eval(value)
+    return defaults
+
+
+def get_all_args():
+    # Config setup. Order of preference will be: 
+    #   1. Default settings are in defaults.ini file
+    #   2. if --wandb-config is given, pull config from wandb to override defaults
+    #   3. Any new command-line arguments override whatever was set earlier
+    defaults, defaults_text = read_defaults()
+    args = setup_args(defaults, defaults_text=defaults_text)  # 1.
+    if args.wandb_config is not None:
+        defaults = pull_wandb_config(args.wandb_config, defaults) # 2.
+    args = setup_args(defaults, defaults_text=defaults_text) # 3. this time cmd-line overrides what's there
+    return args
+
+
+def wandb_log_config(wandb_logger, args): 
+    "save config to wandb (for possible retrieval later)"
+    if hasattr(wandb_logger.experiment.config, 'update'): 
+        wandb_logger.experiment.config.update(args)

--- a/defaults.ini
+++ b/defaults.ini
@@ -1,8 +1,5 @@
 
 [DEFAULTS]
-# non-defaults currently used by zach:
-# --batch-size 16 --num-gpus 8 --num-workers 12 --codebook-size 2048 --num-quantizers 4 --sample-size 32768 --latent-dim 32 --demo-every 10 --demo-steps 250 --num-demos 16 --seed 42
-
 # number of CPU workers for the DataLoader
 num_workers = 2 
 
@@ -51,4 +48,5 @@ num_quantizers = 8
 # If true training data is kept in RAM
 cache_training_data = False  
 
-
+# BTW:  non-defaults currently used by zach, May 25 2022:
+# --batch-size 16 --num-gpus 8 --num-workers 12 --codebook-size 2048 --num-quantizers 4 --sample-size 32768 --latent-dim 32 --demo-every 10 --demo-steps 250 --num-demos 16 --seed 42

--- a/defaults.ini
+++ b/defaults.ini
@@ -1,0 +1,54 @@
+
+[DEFAULTS]
+# non-defaults currently used by zach:
+# --batch-size 16 --num-gpus 8 --num-workers 12 --codebook-size 2048 --num-quantizers 4 --sample-size 32768 --latent-dim 32 --demo-every 10 --demo-steps 250 --num-demos 16 --seed 42
+
+# number of CPU workers for the DataLoader
+num_workers = 2 
+
+# number of GPUs to use for training
+num_gpus = 1 
+
+# The sample rate of the audio
+sample_rate = 48000  
+
+# Number of samples to train on must be a multiple of 16384
+sample_size = 65536 
+
+# Number of epochs between demos
+demo_every = 10    
+   
+# Number of denoising steps for the demos       
+demo_steps = 500            
+
+# Number of demos to create
+num_demos = 8
+
+# Number of steps between checkpoints
+checkpoint_every = 20000     
+
+# Batches for gradient accumulation
+accum_batches = 2             
+
+# the batch size
+batch_size = 8               
+
+# the EMA decay
+ema_decay = 0.99             
+
+# the random seed
+seed = 0                     
+
+# the validation set
+latent_dim = 32              
+
+# the validation set
+codebook_size = 1024         
+
+# number of quantizers
+num_quantizers = 8           
+
+# If true training data is kept in RAM
+cache_training_data = False  
+
+

--- a/run_dvae.py
+++ b/run_dvae.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+
+import argparse
+from contextlib import contextmanager
+from copy import deepcopy
+import math
+from pathlib import Path
+
+import sys
+import torch
+from torch import optim, nn
+from torch.nn import functional as F
+from torch.utils import data
+from tqdm import trange
+import pytorch_lightning as pl
+from pytorch_lightning.utilities.distributed import rank_zero_only
+from einops import rearrange
+
+import torchaudio
+import wandb
+
+from dataset.dataset import SampleDataset
+from diffusion.model import SkipBlock, FourierFeatures, expand_to_planes, ema_update
+#from diffusion.pqmf import CachedPQMF as PQMF
+from encoders.encoders import ResConvBlock, SoundStreamXLEncoder
+from nwt_pytorch import Memcodes
+
+class DiffusionDecoder(nn.Module):
+    def __init__(self, latent_dim, io_channels, depth=16):
+        super().__init__()
+        max_depth = 16
+        depth = min(depth, max_depth)
+        c_mults = [256, 256, 512, 512] + [512] * 12
+        c_mults = c_mults[:depth]
+
+        self.io_channels = io_channels
+        self.timestep_embed = FourierFeatures(1, 16)
+        block = nn.Identity()
+        for i in range(depth, 0, -1):
+            c = c_mults[i - 1]
+            if i > 1:
+                c_prev = c_mults[i - 2]
+                block = SkipBlock(
+                    nn.AvgPool1d(2),
+                    ResConvBlock(c_prev, c, c),
+                    ResConvBlock(c, c, c),
+                    ResConvBlock(c, c, c),
+                    block,
+                    ResConvBlock(c * 2 if i != depth else c, c, c),
+                    ResConvBlock(c, c, c),
+                    ResConvBlock(c, c, c_prev),
+                    nn.Upsample(scale_factor=2, mode='linear', align_corners=False),
+                )
+            else:
+                block = nn.Sequential(
+                    ResConvBlock(io_channels + 16 + latent_dim, c, c),
+                    ResConvBlock(c, c, c),
+                    ResConvBlock(c, c, c),
+                    block,
+                    ResConvBlock(c * 2, c, c),
+                    ResConvBlock(c, c, c),
+                    ResConvBlock(c, c, io_channels, is_last=True),
+                )
+        self.net = block
+
+    def forward(self, input, t, quantized):
+        timestep_embed = expand_to_planes(self.timestep_embed(t[:, None]), input.shape)
+        quantized = F.interpolate(quantized, (input.shape[2], ), mode='linear', align_corners=False)
+        return self.net(torch.cat([input, timestep_embed, quantized], dim=1))
+
+# Define the noise schedule and sampling loop
+def get_alphas_sigmas(t):
+    """Returns the scaling factors for the clean image (alpha) and for the
+    noise (sigma), given a timestep."""
+    return torch.cos(t * math.pi / 2), torch.sin(t * math.pi / 2)
+
+def get_crash_schedule(t):
+    sigma = torch.sin(t * math.pi / 2) ** 2
+    alpha = (1 - sigma ** 2) ** 0.5
+    return alpha_sigma_to_t(alpha, sigma)
+
+def alpha_sigma_to_t(alpha, sigma):
+    """Returns a timestep, given the scaling factors for the clean image and for
+    the noise."""
+    return torch.atan2(sigma, alpha) / math.pi * 2
+
+@torch.no_grad()
+def sample(model, x, steps, eta, logits):
+    """Draws samples from a model given starting noise."""
+    ts = x.new_ones([x.shape[0]])
+
+    # Create the noise schedule
+    t = torch.linspace(1, 0, steps + 1)[:-1]
+    alphas, sigmas = get_alphas_sigmas(get_crash_schedule(t))
+
+    # The sampling loop
+    for i in trange(steps):
+
+        # Get the model output (v, the predicted velocity)
+        with torch.cuda.amp.autocast():
+            v = model(x, ts * t[i], logits).float()
+
+        # Predict the noise and the denoised image
+        pred = x * alphas[i] - v * sigmas[i]
+        eps = x * sigmas[i] + v * alphas[i]
+
+        # If we are not on the last timestep, compute the noisy image for the
+        # next timestep.
+        if i < steps - 1:
+            # If eta > 0, adjust the scaling factor for the predicted noise
+            # downward according to the amount of additional noise to add
+            ddim_sigma = eta * (sigmas[i + 1]**2 / sigmas[i]**2).sqrt() * \
+                (1 - alphas[i]**2 / alphas[i + 1]**2).sqrt()
+            adjusted_sigma = (sigmas[i + 1]**2 - ddim_sigma**2).sqrt()
+
+            # Recombine the predicted noise and predicted denoised image in the
+            # correct proportions for the next step
+            x = pred * alphas[i + 1] + eps * adjusted_sigma
+
+            # Add the correct amount of fresh noise
+            if eta:
+                x += torch.randn_like(x) * ddim_sigma
+
+    # If we are on the last timestep, output the denoised image
+    return pred
+
+
+class ToMode:
+    def __init__(self, mode):
+        self.mode = mode
+
+    def __call__(self, image):
+        return image.convert(self.mode)
+
+
+def ramp(x1, x2, y1, y2):
+    def wrapped(x):
+        if x <= x1:
+            return y1
+        if x >= x2:
+            return y2
+        fac = (x - x1) / (x2 - x1)
+        return y1 * (1 - fac) + y2 * fac
+    return wrapped
+
+
+class DiffusionDVAE(pl.LightningModule):
+    def __init__(self, global_args):
+        super().__init__()
+
+        #self.encoder = Encoder(global_args.codebook_size, 2)
+        self.encoder = SoundStreamXLEncoder(32, global_args.latent_dim, n_io_channels=2, strides=[2, 2, 4, 5, 8], c_mults=[2, 4, 4, 8, 16])
+        self.encoder_ema = deepcopy(self.encoder)
+        self.diffusion = DiffusionDecoder(global_args.latent_dim, 2)
+        self.diffusion_ema = deepcopy(self.diffusion)
+        self.rng = torch.quasirandom.SobolEngine(1, scramble=True)
+        self.ema_decay = global_args.ema_decay
+
+        self.quantizer = Memcodes(
+            dim=global_args.latent_dim,
+            heads=global_args.num_quantizers,
+            num_codes=global_args.codebook_size,
+            temperature=1.
+        )
+
+        # self.pqmf_bands = global_args.pqmf_bands
+
+        # if self.pqmf_bands > 1:
+        #     self.pqmf = PQMF(2, 70, global_args.pqmf_bands)
+
+    def encode(self, *args, **kwargs):
+        if self.training:
+            return self.encoder(*args, **kwargs)
+        return self.encoder_ema(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        if self.training:
+            return self.diffusion(*args, **kwargs)
+        return self.diffusion_ema(*args, **kwargs)
+
+    def configure_optimizers(self):
+        return optim.Adam([*self.encoder.parameters(), *self.diffusion.parameters()], lr=2e-5)
+
+  
+    def training_step(self, batch, batch_idx):
+        reals = batch[0]
+
+        encoder_input = reals
+
+        # if self.pqmf_bands > 1:
+        #     encoder_input = self.pqmf(reals)
+        
+        # Draw uniformly distributed continuous timesteps
+        t = self.rng.draw(reals.shape[0])[:, 0].to(self.device)
+
+        # Calculate the noise schedule parameters for those timesteps
+        alphas, sigmas = get_alphas_sigmas(get_crash_schedule(t))
+
+        # Combine the ground truth images and the noise
+        alphas = alphas[:, None, None]
+        sigmas = sigmas[:, None, None]
+        noise = torch.randn_like(reals)
+        noised_reals = reals * alphas + noise * sigmas
+        targets = noise * alphas - reals * sigmas
+
+        # Compute the model output and the loss.
+        with torch.cuda.amp.autocast():
+            tokens = self.encoder(encoder_input).float()
+
+        #Rearrange for Memcodes
+        tokens = rearrange(tokens, 'b d n -> b n d')
+
+        #Quantize into memcodes
+        quantized, _ = self.quantizer(tokens)
+
+        quantized = rearrange(quantized, 'b n d -> b d n')
+
+        # p = torch.rand([reals.shape[0], 1], device=reals.device)
+        # quantized = torch.where(p > 0.2, quantized, torch.zeros_like(quantized))
+
+        with torch.cuda.amp.autocast():
+            v = self.diffusion(noised_reals, t, quantized)
+            mse_loss = F.mse_loss(v, targets)
+            loss = mse_loss
+
+        log_dict = {
+            'train/loss': loss.detach(),
+            'train/mse_loss': mse_loss.detach(),
+        }
+
+        self.log_dict(log_dict, prog_bar=True, on_step=True)
+        return loss
+
+    def on_before_zero_grad(self, *args, **kwargs):
+        decay = 0.95 if self.current_epoch < 25 else self.ema_decay
+        ema_update(self.diffusion, self.diffusion_ema, decay)
+        ema_update(self.encoder, self.encoder_ema, decay)
+
+class ExceptionCallback(pl.Callback):
+    def on_exception(self, trainer, module, err):
+        print(f'{type(err).__name__}: {err}', file=sys.stderr)
+
+
+class DemoCallback(pl.Callback):
+    def __init__(self, demo_dl, global_args):
+        super().__init__()
+        self.demo_every = global_args.demo_every
+        self.demo_samples = global_args.sample_size
+        self.demo_steps = global_args.demo_steps
+        self.demo_dl = iter(demo_dl)
+        self.sample_rate = global_args.sample_rate
+        # self.pqmf_bands = global_args.pqmf_bands
+
+        # if self.pqmf_bands > 1:
+        #     self.pqmf = PQMF(2, 70, global_args.pqmf_bands)
+
+    @rank_zero_only
+    @torch.no_grad()
+    def on_train_epoch_end(self, trainer, module):
+        #last_demo_step = -1
+        #if (trainer.global_step - 1) % self.demo_every != 0 or last_demo_step == trainer.global_step:
+        if trainer.current_epoch % self.demo_every != 0:
+            return
+        
+        #last_demo_step = trainer.global_step
+
+        demo_reals, _ = next(self.demo_dl)
+
+        encoder_input = demo_reals
+        
+        # if self.pqmf_bands > 1:
+        #     encoder_input = self.pqmf(demo_reals)
+        
+        encoder_input = encoder_input.to(module.device)
+
+        demo_reals = demo_reals.to(module.device)
+
+        noise = torch.randn([demo_reals.shape[0], 2, self.demo_samples]).to(module.device)
+
+        tokens = module.encoder_ema(encoder_input)
+
+        #Rearrange for Memcodes
+        tokens = rearrange(tokens, 'b d n -> b n d')
+
+        quantized, _= module.quantizer(tokens)
+        quantized = rearrange(quantized, 'b n d -> b d n')
+
+        fakes = sample(module.diffusion_ema, noise, self.demo_steps, 1, quantized)
+
+        # # undo the PQMF encoding
+        # if self.pqmf_bands > 1:
+        #     fakes = self.pqmf.inverse(fakes.cpu())
+
+        # Put the demos together
+        fakes = rearrange(fakes, 'b d n -> d (b n)')
+        demo_reals = rearrange(demo_reals, 'b d n -> d (b n)')
+
+        #demo_audio = torch.cat([demo_reals, fakes], -1)
+
+        try:
+            log_dict = {}
+            
+            filename = f'recon_{trainer.global_step:08}.wav'
+            fakes = fakes.clamp(-1, 1).mul(32767).to(torch.int16).cpu()
+            torchaudio.save(filename, fakes, self.sample_rate)
+
+            reals_filename = f'reals_{trainer.global_step:08}.wav'
+            demo_reals = demo_reals.clamp(-1, 1).mul(32767).to(torch.int16).cpu()
+            torchaudio.save(reals_filename, demo_reals, self.sample_rate)
+
+
+            log_dict[f'recon'] = wandb.Audio(filename,
+                                                sample_rate=self.sample_rate,
+                                                caption=f'Reconstructed')
+            log_dict[f'real'] = wandb.Audio(reals_filename,
+                                                sample_rate=self.sample_rate,
+                                                caption=f'Real')
+            trainer.logger.experiment.log(log_dict, step=trainer.global_step)
+        except Exception as e:
+            print(f'{type(e).__name__}: {e}', file=sys.stderr)
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--training-dir', type=Path, required=True,
+                   help='the training data directory')
+    p.add_argument('--name', type=str, required=True,
+                   help='the name of the run')
+    p.add_argument('--num-workers', type=int, default=2,
+                   help='number of CPU workers for the DataLoader')
+    p.add_argument('--num-gpus', type=int, default=1,
+                   help='number of GPUs to use for training')
+    
+    p.add_argument('--sample-rate', type=int, default=48000,
+                   help='The sample rate of the audio')
+    p.add_argument('--sample-size', type=int, default=65536,
+                   help='Number of samples to train on, must be a multiple of 16384')
+    p.add_argument('--demo-every', type=int, default=10,
+                   help='Number of epochs between demos')
+    p.add_argument('--demo-steps', type=int, default=500,
+                   help='Number of denoising steps for the demos')
+    p.add_argument('--num-demos', type=int, default=8,
+                   help='Number of demos to create')
+    p.add_argument('--checkpoint-every', type=int, default=20000,
+                   help='Number of steps between checkpoints')
+    p.add_argument('--accum-batches', type=int, default=2,
+                   help='Batches for gradient accumulation')
+    p.add_argument('--batch-size', '-bs', type=int, default=8,
+                   help='the batch size')
+
+    p.add_argument('--ema-decay', type=float, default=0.995,
+                   help='the EMA decay')
+    p.add_argument('--seed', type=int, default=0,
+                   help='the random seed')
+    
+    p.add_argument('--latent-dim', type=int, default=32,
+                   help='the validation set')
+    p.add_argument('--codebook-size', type=int, default=1024,
+                   help='the validation set')
+    p.add_argument('--num-quantizers', type=int, default=8,
+                   help='number of quantizers')
+    p.add_argument('--cache-training-data', type=bool, default=False,
+                   help='If true, training data is kept in RAM')
+
+    # p.add_argument('--val-set', type=str, required=True,
+    #                help='the validation set')
+    # p.add_argument('--pqmf-bands', type=int, default=1,
+    #                help='number of sub-bands for the PQMF filter')
+
+    args = p.parse_args()
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print('Using device:', device)
+    torch.manual_seed(args.seed)
+
+    train_set = SampleDataset([args.training_dir], args)
+    train_dl = data.DataLoader(train_set, args.batch_size, shuffle=True,
+                               num_workers=args.num_workers, persistent_workers=True, pin_memory=True)
+    wandb_logger = pl.loggers.WandbLogger(project=args.name)
+    demo_dl = data.DataLoader(train_set, args.num_demos, shuffle=True)
+    
+    exc_callback = ExceptionCallback()
+    ckpt_callback = pl.callbacks.ModelCheckpoint(every_n_train_steps=args.checkpoint_every, save_top_k=-1)
+    demo_callback = DemoCallback(demo_dl, args)
+    diffusion_model = DiffusionDVAE(args)
+    wandb_logger.watch(diffusion_model)
+
+    diffusion_trainer = pl.Trainer(
+        gpus=args.num_gpus,
+        strategy='ddp',
+        precision=16,
+        accumulate_grad_batches={
+            0:1, 
+            1: args.accum_batches #Start without accumulation
+            # 5:2,
+            # 10:3, 
+            # 12:4, 
+            # 14:5, 
+            # 16:6, 
+            # 18:7,  
+            # 20:8
+            }, 
+        callbacks=[ckpt_callback, demo_callback, exc_callback],
+        logger=wandb_logger,
+        log_every_n_steps=1,
+        max_epochs=10000000,
+    )
+
+    diffusion_trainer.fit(diffusion_model, train_dl)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
New capabilities for archiving run settings and pulling configurations from previous runs.  With just 3 lines of code 😎 : the import, the arg setup, & the wandb push.  
 
Put `defaults.ini` in your main directory.  Grab my `configger/` directory. Then you'll be adding only 3 lines of code to your existing run script (and deleting or commenting-out a bunch of others).  

What you get from this are new config-archiving capabilities.  Options `--config-file` and `--wandb-config` (which pulls previous runs' configs off wandb). The latter overrides the former, and any new cmd line options override both of those. 

You can use `--wandb-config` and then the url of any one of your runs to override those defaults: 

e.g. `--wandb-config='https://wandb.ai/drscotthawley/delete-me/runs/1m2gh3o1?workspace=user-drscotthawley'`
(i.e., whatever URL you grab from your browser window when looking at an individual run.)  

**NOTE: the `--wandb-config` thing can only pull from WandB runs that used configger, i.e. that have logged a "wandb config push".** 


## 1st line to add
In your run/training code, add this near the top:

```Python
from configger.configger import get_all_args, wandb_log_config 
```

## 2nd line to add
Near the top of your `main()`, add this:

```Python
args = get_all_args()
```

Further down in your code, comment-out (or delete) *all* your command-line arguments. If you want different command-line arguments, then add or change them in defaults.ini.  The 'help' string for these is provided via  comment in the line preceding your variable. (see defaults.ini for examples)


## 3rd line to add
and then right after you define the wandb logger, run

```Python
wandb_log_config(wandb_logger, args)
```


## Sample usage:

```Python
from configger.configger import get_all_args, wandb_log_config 


def main():

    # Config setup. Order of preference will be: 
    #   1. Default settings are in defaults.ini file or whatever you specify via --config-file
    #   2. if --wandb-config is given, pull config from wandb to override defaults
    #   3. Any new command-line arguments override whatever was set earlier
    args = get_all_args()

    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
    torch.manual_seed(args.seed)

    train_set = SampleDataset([args.training_dir], args)
    train_dl = data.DataLoader(train_set, args.batch_size, shuffle=True,
                               num_workers=args.num_workers, persistent_workers=True, pin_memory=True)
    wandb_logger = pl.loggers.WandbLogger(project=args.name)
    wandb_log_config(wandb_logger, args) # push config to wandb for archiving
 
    demo_dl = data.DataLoader(train_set, args.num_demos, shuffle=True)

```

